### PR TITLE
Change collection type to 'multi

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,4 +1,5 @@
 #lang info
+(define collection 'multi)
 (define deps '("base"))
 (define build-deps '("rackunit-lib" "racket-doc" "scribble-lib"))
 (define scribblings '(("doc/ftree.scrbl" () ("Data Structures"))))


### PR DESCRIPTION
I was having trouble using this package once it was installed;
forms like (require ftree) and (require pqueue) would throw an
error. Changing the collection type to 'multi fixes this.

This also fixes a couple scribble warnings that occur upon
installation.