### PR TITLE
Fix collection paths again so docs will render

### DIFF
--- a/doc/ftree.scrbl
+++ b/doc/ftree.scrbl
@@ -1,20 +1,20 @@
 #lang scribble/manual
 @(require scribble/eval
-          (for-label ftree/ftree/ftree
-                     ftree/raseq/raseq
-                     ftree/pqueue/pqueue
-                     ftree/orderedseq/orderedseq
-                     ftree/intervaltree/intervaltree)
+          (for-label ftree
+                     raseq
+                     pqueue
+                     orderedseq
+                     intervaltree)
           racket/base)
 
 @title{Finger Trees}
 
 @(define the-eval (make-base-eval))
-@(the-eval '(require ftree/ftree/ftree
-                     ftree/raseq/raseq
-                     ftree/pqueue/pqueue
-                     ftree/orderedseq/orderedseq
-                     ftree/intervaltree/intervaltree))
+@(the-eval '(require ftree
+                     raseq
+                     pqueue/pqueue
+                     orderedseq/orderedseq
+                     intervaltree/intervaltree))
 
 
 @author[@author+email["Stephen Chang" "stchang@racket-lang.org"]]
@@ -29,7 +29,7 @@ This implementation currently does not utilize laziness, because preliminary ben
 
 @section{Finger Trees}
 
-@defmodule[ftree #:use-sources (ftree/ftree/ftree)]
+@defmodule[ftree #:use-sources (ftree)]
 
 @defproc[(mk-ftree [∅ any/c][elem-sz (-> any/c any/c)][⊕ (-> any/c any/c any/c)]) ftree?]{
   Creates an empty @deftech{finger tree}. @racket[∅] is the "measurement" of the empty tree. @racket[elem-sz] takes an element in the tree and returns the measurement for that element. Finally, @racket[⊕] must be an associative binary operation that combines measurements.}
@@ -80,7 +80,7 @@ This implementation currently does not utilize laziness, because preliminary ben
 
 @section{Random-Access Sequences}
 
-@defmodule[raseq #:use-sources (ftree/raseq/raseq)]
+@defmodule[raseq #:use-sources (raseq)]
 
 @defproc[(raseq? [x any/c]) boolean?]{Identifies random-access sequences.}
 @defproc[(mk-raseq) raseq?]{Makes an empty random access sequence.}
@@ -97,7 +97,7 @@ This implementation currently does not utilize laziness, because preliminary ben
 
 @section{Priority Queues}
 
-@defmodule[pqueue #:use-sources (ftree/pqueue/pqueue)]
+@defmodule[pqueue #:use-sources (pqueue)]
 
 @defproc[(pqueue? [x any/c]) boolean?]{Identifies priority queues.}
 @defproc[(mk-pqueue [<= (-> any/c any/c boolean?)]) pqueue?]{
@@ -113,7 +113,7 @@ This implementation currently does not utilize laziness, because preliminary ben
 
 @section{Ordered Sequences}
 
-@defmodule[orderedseq #:use-sources (ftree/orderedseq/orderedseq)]
+@defmodule[orderedseq #:use-sources (orderedseq)]
 
 From Hinze and Paterson's paper:
  "ordered sequences [can be seen as an optimization] of, and subsume, priority
@@ -150,7 +150,7 @@ Differences with pqueues:
 
 @section{Interval Trees}
 
-@defmodule[intervaltree #:use-sources (ftree/intervaltree/intervaltree)]
+@defmodule[intervaltree #:use-sources (intervaltree)]
 
 Represents sets of intervals where an interval is a pair of real numbers, lo and hi, with lo <= hi. Intervals are sorted in ascending order of the lo's, when added via @racket[it-insert] (but not with any of the @racket[ft-cons] functions). The cached measure is an interval where the lo is the lo of the rightmost element and the hi is the maximum of the element hi's.
 


### PR DESCRIPTION
This change is most likely needed because collection type was changed to 'multi in 2019